### PR TITLE
fix error handler parameters

### DIFF
--- a/src/Application/Http/Middleware/ErrorMiddleware.php
+++ b/src/Application/Http/Middleware/ErrorMiddleware.php
@@ -56,7 +56,7 @@ class ErrorMiddleware implements MiddlewareInterface
             string $errorString,
             string $errorFile,
             int $errorLine,
-            ?array $errorContext
+            ?array $errorContext = null
         ): bool {
             if (!(error_reporting() & $errorNumber)) {
                 // Error is not in mask


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

An error occurred with PHP8 because an empty parameter
